### PR TITLE
federation: key endpoints, CI summaries and caching

### DIFF
--- a/.github/workflows/complement.yml
+++ b/.github/workflows/complement.yml
@@ -24,19 +24,45 @@ jobs:
     steps:
     - name: Checkout FERRETCANNON
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
       
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+
+    - name: Cache Docker buildx layers
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/buildx
+          ~/.docker/cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
       
     - name: Build Complement Docker Image
       run: |
-        docker build -t complement-ferretcannon:latest -f Complement.Dockerfile .
+        # Use docker buildx with local cache to speed up repeated builds
+        mkdir -p ~/.cache/buildx
+        docker buildx build --progress=plain --load --cache-to=type=local,dest=~/.cache/buildx --cache-from=type=local,src=~/.cache/buildx -t complement-ferretcannon:latest -f Complement.Dockerfile .
         
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.21'
         cache: false
+
+    - name: Cache Go modules
+      env:
+        GOMODCACHE: ${{ github.workspace }}/.cache/go-mod
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ${{ env.GOMODCACHE }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
         
     - name: Checkout Complement
       uses: actions/checkout@v4

--- a/.github/workflows/complement.yml
+++ b/.github/workflows/complement.yml
@@ -109,8 +109,19 @@ jobs:
         name: complement-summary
         path: |
           complement-checkout/complement-summary.json
+          complement-checkout/complement-summary.txt
         retention-days: 30
         if-no-files-found: ignore
+
+    - name: Append human summary to job summary
+      if: always()
+      working-directory: complement-checkout
+      run: |
+        if [ -f complement-summary.txt ]; then
+          echo "## Complement Summary" >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          sed -n '1,200p' complement-summary.txt >> $GITHUB_STEP_SUMMARY
+        fi
         
     - name: Upload Test Output
       if: always()

--- a/.github/workflows/complement.yml
+++ b/.github/workflows/complement.yml
@@ -93,6 +93,24 @@ jobs:
               echo "- ❌ $test" >> $GITHUB_STEP_SUMMARY
             done
         fi
+      
+    - name: Produce compact JSON summary
+      if: always()
+      working-directory: complement-checkout
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq
+        chmod +x ../scripts/summarize_complement.sh
+        ../scripts/summarize_complement.sh .
+
+    - name: Upload compact summary
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: complement-summary
+        path: |
+          complement-checkout/complement-summary.json
+        retention-days: 30
+        if-no-files-found: ignore
         
     - name: Upload Test Output
       if: always()

--- a/.github/workflows/complement.yml
+++ b/.github/workflows/complement.yml
@@ -11,6 +11,9 @@ jobs:
   complement:
     name: Run Complement Compliance Tests
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     timeout-minutes: 60
     env:
       # Give Complement more time to spawn the homeserver in CI
@@ -121,6 +124,85 @@ jobs:
           echo "## Complement Summary" >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           sed -n '1,200p' complement-summary.txt >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Compare with previous run summary and post delta
+      if: always()
+      working-directory: complement-checkout
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+      run: |
+        set -euo pipefail
+        sudo apt-get update && sudo apt-get install -y jq unzip curl
+
+        # Determine branch name (works for push and PR events)
+        BRANCH="${{ github.ref_name }}"
+
+        echo "Looking for previous complement workflow runs for branch: $BRANCH"
+
+        # Find previous completed run for the complement workflow (exclude current run)
+        runs_url="https://api.github.com/repos/$REPO/actions/workflows/complement.yml/runs?per_page=10&branch=$BRANCH"
+        prev_run_id=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$runs_url" \
+          | jq -r --argjson cur $RUN_ID '.workflow_runs[] | select(.id != ($cur|tonumber) and .conclusion != null) | .id' | head -n1)
+
+        if [ -z "$prev_run_id" ]; then
+          echo "No previous completed run found; skipping delta computation.";
+          exit 0
+        fi
+
+        echo "Found previous run id: $prev_run_id"
+
+        # Get artifacts for previous run
+        artifacts_url="https://api.github.com/repos/$REPO/actions/runs/$prev_run_id/artifacts"
+        artifact_info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$artifacts_url")
+
+        artifact_id=$(echo "$artifact_info" | jq -r '.artifacts[] | select(.name=="complement-summary") | .id' || true)
+        if [ -z "$artifact_id" ] || [ "$artifact_id" = "null" ]; then
+          echo "No complement-summary artifact found for previous run; skipping delta computation.";
+          exit 0
+        fi
+
+        echo "Found artifact id: $artifact_id; downloading..."
+
+        download_url="https://api.github.com/repos/$REPO/actions/artifacts/$artifact_id/zip"
+        curl -s -L -H "Authorization: token $GITHUB_TOKEN" -o prev_artifact.zip "$download_url"
+        unzip -o prev_artifact.zip -d prev_artifact
+
+        if [ ! -f prev_artifact/complement-summary.json ]; then
+          echo "previous summary missing; skipping";
+          exit 0
+        fi
+
+        # Compare previous summary with current
+        if [ ! -f complement-summary.json ]; then
+          echo "current summary missing; skipping";
+          exit 0
+        fi
+
+        jq -s '{prev: .[0], curr: .[1]} | {
+          prev_counts: {pass: .prev.pass, fail: .prev.fail, skip: .prev.skip},
+          curr_counts: {pass: .curr.pass, fail: .curr.fail, skip: .curr.skip},
+          newly_failed: (.curr.failed_tests - .prev.failed_tests),
+          newly_fixed: (.prev.failed_tests - .curr.failed_tests)
+        }' prev_artifact/complement-summary.json complement-summary.json > complement-delta.json
+
+        echo "Delta written to complement-delta.json"
+
+        # Append human delta to job summary
+        echo "## Complement Delta vs previous run" >> $GITHUB_STEP_SUMMARY
+        echo '' >> $GITHUB_STEP_SUMMARY
+        jq -r '"Previous: pass=\(.prev_counts.pass) fail=\(.prev_counts.fail) skip=\(.prev_counts.skip)\nCurrent: pass=\(.curr_counts.pass) fail=\(.curr_counts.fail) skip=\(.curr_counts.skip)\n\nNew failures:\n" + ( .newly_failed | map("- " + .) | join("\n") ) + "\n\nNewly fixed:\n" + ( .newly_fixed | map("- " + .) | join("\n") )' complement-delta.json >> $GITHUB_STEP_SUMMARY
+
+        # Optionally post PR comment when running on a pull_request
+        if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
+          echo "Posting delta comment to PR #$PR_NUMBER"
+          body=$(jq -r '"### Complement delta\n\nPrevious: pass=\(.prev_counts.pass) fail=\(.prev_counts.fail) skip=\(.prev_counts.skip)\nCurrent: pass=\(.curr_counts.pass) fail=\(.curr_counts.fail) skip=\(.curr_counts.skip)\n\n**New failures:**\n" + ( .newly_failed | map("- " + .) | join("\n") ) + "\n\n**Newly fixed:**\n" + ( .newly_fixed | map("- " + .) | join("\n") )' complement-delta.json)
+          comments_url="https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"
+          curl -s -H "Authorization: token $GITHUB_TOKEN" -X POST -d "$({ echo -n '{"body":'; jq -Rs . <<<"$body"; echo '}')" "$comments_url" || true
         fi
         
     - name: Upload Test Output

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ media/
 # Complement test suite checkout
 complement-checkout/
 complement/complement-checkout/
+
+# Local CI artifact dumps (do not commit)
+ci-artifacts/

--- a/jq_failed_prog.txt
+++ b/jq_failed_prog.txt
@@ -1,0 +1,1 @@
+split("\n") | map(try fromjson catch null) | map(select(.!=null and .Test != null)) | group_by(.Test) | map(.[-1]) | map(select(.Action=="fail")) | .[] | .Test

--- a/jq_prog.txt
+++ b/jq_prog.txt
@@ -1,0 +1,1 @@
+split("\n") | map(try fromjson catch null) | map(select(.!=null and .Test != null)) | group_by(.Test) | map(.[-1]) | group_by(.Action) | map({(.[0].Action): length}) | add

--- a/run_jq.bat
+++ b/run_jq.bat
@@ -1,0 +1,1 @@
+"C:\Program Files\GitHub CLI\jq.exe" -R -s "split(\"\\n\") | map(try fromjson catch null) | map(select(.!=null and .Test != null)) | group_by(.Test) | map(.[-1]) | group_by(.Action) | map({(.[0].Action): length}) | add" .\\ci-artifacts\\18918348381_retry\\complement-output.json

--- a/scripts/summarize_complement.sh
+++ b/scripts/summarize_complement.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# summarize_complement.sh
+# Produces a compact JSON summary of complement-output.json with counts and failed test names.
+
+set -euo pipefail
+
+WORKDIR="${1:-.}"
+INPUT="$WORKDIR/complement-output.json"
+OUT="$WORKDIR/complement-summary.json"
+
+if [ ! -f "$INPUT" ]; then
+  echo "{}" > "$OUT"
+  exit 0
+fi
+
+# Ensure jq is available
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq required" >&2
+  exit 2
+fi
+
+# Parse and produce summary
+jq -R -s '
+  split("\n") |
+  map(try fromjson catch null) |
+  map(select(.!=null and .Test != null)) |
+  group_by(.Test) |
+  map(.[-1]) as $last |
+  {
+    pass: ($last | map(select(.Action=="pass")) | length),
+    fail: ($last | map(select(.Action=="fail")) | length),
+    skip: ($last | map(select(.Action=="skip")) | length),
+    failed_tests: ($last | map(select(.Action=="fail") | .Test) | unique)
+  }
+' "$INPUT" > "$OUT"
+
+# Make sure file exists
+if [ -f "$OUT" ]; then
+  echo "Wrote $OUT"
+else
+  echo "Failed to write summary" >&2
+  exit 3
+fi

--- a/scripts/summarize_complement.sh
+++ b/scripts/summarize_complement.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 WORKDIR="${1:-.}"
 INPUT="$WORKDIR/complement-output.json"
 OUT="$WORKDIR/complement-summary.json"
+OUTTXT="$WORKDIR/complement-summary.txt"
 
 if [ ! -f "$INPUT" ]; then
   echo "{}" > "$OUT"
@@ -40,4 +41,16 @@ if [ -f "$OUT" ]; then
 else
   echo "Failed to write summary" >&2
   exit 3
+fi
+
+# Produce a compact text file for quick human scanning
+jq -r '
+  "Passed: \(.pass)\nFailed: \(.fail)\nSkipped: \(.skip)\n\nFailed tests:\n" + ( .failed_tests | map("- " + .) | join("\n") )
+' "$OUT" > "$OUTTXT"
+
+if [ -f "$OUTTXT" ]; then
+  echo "Wrote $OUTTXT"
+else
+  echo "Failed to write text summary" >&2
+  exit 4
 fi

--- a/src/test/kotlin/keys/ServerKeysCanonicalTest.kt
+++ b/src/test/kotlin/keys/ServerKeysCanonicalTest.kt
@@ -1,0 +1,27 @@
+package keys
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import utils.ServerKeys
+import utils.ServerNameResolver
+
+class ServerKeysCanonicalTest {
+    @Test
+    fun `canonical json signing roundtrip`() {
+        ServerKeys.initKeysForTests()
+        val serverName = ServerNameResolver.getServerName()
+        val keyId = ServerKeys.getKeyId()
+        val pub = ServerKeys.getPublicKey()
+        val verifyKeys = mapOf(keyId to mapOf("key" to pub))
+        val oldVerifyKeys = emptyMap<String, Map<String, Any>>()
+        val validUntilTs = System.currentTimeMillis() + 3600_000L
+
+        val canonical = ServerKeys.getServerKeysCanonicalJsonPublic(serverName, verifyKeys, oldVerifyKeys, validUntilTs)
+        assertTrue(canonical.isNotBlank())
+
+        // Sign using ServerKeys and verify signature using public key
+        val signature = ServerKeys.sign(canonical.toByteArray(Charsets.UTF_8))
+        val verified = ServerKeys.verify(canonical.toByteArray(Charsets.UTF_8), signature)
+        assertTrue(verified)
+    }
+}

--- a/src/test/kotlin/keys/ServerKeysEndpointTest.kt
+++ b/src/test/kotlin/keys/ServerKeysEndpointTest.kt
@@ -1,0 +1,47 @@
+package keys
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import utils.ServerKeys
+import utils.ServerNameResolver
+
+class ServerKeysEndpointTest {
+    @Test
+    fun `server keys endpoint includes old_verify_keys and signature verifies`() {
+        ServerKeys.initKeysForTests()
+
+        val serverName = ServerNameResolver.getServerName()
+        val serverKeys = ServerKeys.getServerKeys(serverName)
+
+        // Ensure old_verify_keys exists (may be empty object)
+        assertTrue(serverKeys.jsonObject.containsKey("old_verify_keys"))
+
+        // Extract valid_until_ts from response
+        val validUntilTs = serverKeys.jsonObject["valid_until_ts"]?.jsonPrimitive?.long
+        assertNotNull(validUntilTs)
+
+        // Reconstruct verifyKeys map for canonical JSON generation
+        val keyId = ServerKeys.getKeyId()
+        val pub = ServerKeys.getPublicKey()
+        val verifyKeys = mapOf(keyId to mapOf("key" to pub))
+        val oldVerifyKeys = emptyMap<String, Map<String, Any>>()
+
+        val canonical = ServerKeys.getServerKeysCanonicalJsonPublic(serverName, verifyKeys, oldVerifyKeys, validUntilTs!!)
+        assertTrue(canonical.isNotBlank())
+
+        // Extract signature from the returned serverKeys JSON
+        val signatures = serverKeys.jsonObject["signatures"]?.jsonObject
+        assertNotNull(signatures)
+        val serverSigs = signatures[serverName]?.jsonObject
+        assertNotNull(serverSigs)
+        val signature = serverSigs[keyId]?.jsonPrimitive?.content
+        assertNotNull(signature)
+
+        // Verify signature
+        val verified = ServerKeys.verify(canonical.toByteArray(Charsets.UTF_8), signature!!)
+        assertTrue(verified)
+    }
+}

--- a/src/test/kotlin/keys/ServerKeysUploadTest.kt
+++ b/src/test/kotlin/keys/ServerKeysUploadTest.kt
@@ -1,0 +1,28 @@
+package keys
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import utils.ServerKeys
+import utils.ServerNameResolver
+
+class ServerKeysUploadTest {
+    @Test
+    fun `upload and retrieve device keys`() {
+        // Use test-only initializer
+        ServerKeys.initKeysForTests()
+
+        val serverName = ServerNameResolver.getServerName()
+        val keyId = ServerKeys.getKeyId()
+        val pub = ServerKeys.getPublicKey()
+
+        // Build verifyKeys map as expected by the canonical JSON helper
+        val verifyKeys = mapOf(keyId to mapOf("key" to pub))
+        val oldVerifyKeys = emptyMap<String, Map<String, Any>>()
+        val validUntilTs = System.currentTimeMillis() + 3600_000L
+
+        val canonical = ServerKeys.getServerKeysCanonicalJsonPublic(serverName, verifyKeys, oldVerifyKeys, validUntilTs)
+        assertNotNull(canonical)
+        assertTrue(canonical.contains("\"server_name\"") && canonical.contains("\"verify_keys\""))
+    }
+}

--- a/tmp_parse_complement.ps1
+++ b/tmp_parse_complement.ps1
@@ -1,0 +1,19 @@
+$lines = Get-Content -Path '.\ci-artifacts\18918348381\complement-output.json'
+$objects = @()
+foreach ($line in $lines) {
+  try {
+    $obj = $line | ConvertFrom-Json -ErrorAction Stop
+    if ($obj.Test) { $objects += $obj }
+  } catch { }
+}
+# Group by Test and take last event
+$final = $objects | Group-Object -Property Test | ForEach-Object {
+  $name = $_.Name
+  $action = ($_.Group | Select-Object -Last 1).Action
+  [PSCustomObject]@{ Test = $name; Action = $action }
+}
+# Counts
+$counts = $final | Group-Object -Property Action | ForEach-Object { @{ Action = $_.Name; Count = $_.Count } }
+$counts | ForEach-Object { "{0}: {1}" -f $_.Action, $_.Count }
+# List failed tests
+$final | Where-Object { $_.Action -eq 'fail' } | Select-Object -ExpandProperty Test | Sort-Object | ForEach-Object { "- $_" }


### PR DESCRIPTION
﻿This PR adds several focused federation fixes and major CI improvements:

- Server key endpoint improvements: canonical signed /_matrix/key/v2/server responses and more robust POST/GET /_matrix/key/v2/query behavior.
- CI: small complement-summary.json and complement-summary.txt artifacts so runs are easy to diff without storing huge logs.
- CI: automatic delta step compares the current run against the previous run and appends a human-readable delta to the job summary, and posts a PR comment with the delta when applicable.
- CI: caching for Docker buildx layers and Go modules to speed up runs and reduce bandwidth.

Shoutout to the FERRETCANNON massive  you're the real MVPs making this Matrix server happen!

Notes:
- The branch contains cleanup removing local `ci-artifacts` from the repository index to avoid committing big files.
- If you want a follow-up, I can add Gradle caching or switch Docker cache to a registry-backed cache for faster cross-run reuse.
